### PR TITLE
Hestenes' traction and protraction

### DIFF
--- a/galgebra-master/galgebra/lt.py
+++ b/galgebra-master/galgebra/lt.py
@@ -268,6 +268,26 @@ class Lt(object):
         self.Ga.connect_flg = connect_flg
         return(tr_F)
 
+    def traction(self):  # traction(L) defined by traction(L) = grad*L(x)
+
+        connect_flg = self.Ga.connect_flg
+        self.Ga.connect_flg = False
+
+        F_x = mv.Mv(self(self.Ga.lt_x, obj=True), ga=self.Ga)
+        result = self.Ga.grad * F_x
+        self.Ga.connect_flg = connect_flg
+        return(result)
+
+    def protraction(self):  # protraction(L) defined by protraction(L) = grad^L(x)
+
+        connect_flg = self.Ga.connect_flg
+        self.Ga.connect_flg = False
+
+        F_x = mv.Mv(self(self.Ga.lt_x, obj=True), ga=self.Ga)
+        result = self.Ga.grad ^ F_x
+        self.Ga.connect_flg = connect_flg
+        return(result)
+
     def adj(self):
 
         self_adj = []


### PR DESCRIPTION
tr is contraction.  This relatively blindly copies the code for trace and just changes the product (and doesn't project out the scalar.)  All of these (tr too) could alternatively be defined by sums like sum(rv*L(v) for rv, v in zip(ga.mvr(), ga.mv()))

I'm looking into adding similar operations for multilinear transformations.